### PR TITLE
localization fix

### DIFF
--- a/Need For Speed II SE/convert_to_lowercase
+++ b/Need For Speed II SE/convert_to_lowercase
@@ -1,4 +1,5 @@
 #!/bin/bash
+export LC_ALL=C
 
 if [ -z $1 ]; then
 	echo "Usage: $0 DIR1 [DIR2]"


### PR DESCRIPTION
When convert_to_lowercase script run on non-English systems it ends up some files like `englIsh.vIv` and the game closes with signal 11. Maybe the issue #54 will solve with this fix.